### PR TITLE
Set INSTANCE_IP environment to keep multiple instances in sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ class { 'rocketchat':
 }
 ```
 
+In the case of multiple Rocket.Chat instances, the instance identification of each should be an address that can be connected by the others.
+If the host IP Rocket.Chat runs on cannot be used as is from other hosts (or a different naming is preferred), the instance\_ip parameter will need to be changed accordingly.
+Not doing so will cause syncing issues (typing information, audio and desktop notifications, etc).
+
 ## Limitations
 
 Module is tested on Debian 7, 8 and Ubuntu 14.04 and 16.04

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -8,7 +8,8 @@ class rocketchat::service (
   $destination,
   $mongo_port,
   $mongo_replset,
-  $authsource
+  $authsource,
+  $instance_ip = undef
 ) {
 
   file { '/etc/systemd/system/rocket.service':

--- a/templates/rocket.service.erb
+++ b/templates/rocket.service.erb
@@ -13,6 +13,7 @@ RestartSec=10
 StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=rocket.chat
+Environment=INSTANCE_IP=<%= @instance_ip || scope['::facts']['networking']['ip'] %>
 Environment=PORT=<%= @port %>
 Environment=MONGO_URL=mongodb://<%= @mongo_host%>:<%= @mongo_port%>/<%= @database_name%><%= authstring %><%= replstring %>
 Environment=ROOT_URL=<%= @root_url %>


### PR DESCRIPTION
Documentation examples of what might go wrong received from RC devs in
chat and personal experience in production.

The default value RC sets is "undefined", which obviously doesn't work. After the servers come up with the new parameter, the old "undefined" values get deleted in a couple of minutes.