### PR TITLE
replace willdurand-nodejs with the official puppet-nodejs module

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,7 +2,7 @@ fixtures:
 
   repositories:
     stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib"
-    nodejs: 'https://github.com/willdurand/puppet-nodejs'
+    nodejs: 'https://github.com/voxpupuli/puppet-nodejs'
     mongodb: "https://github.com/puppetlabs/puppetlabs-mongodb"
     apt: "https://github.com/puppetlabs/puppetlabs-apt"
     wget: 'https://github.com/maestrodev/puppet-wget.git'

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ Just `include rocketchat` to install Rocket.Chat with managed firewall and Nginx
 
 ```ruby
 class { 'rocketchat':
-  root_url    => 'www.yourcompanydomain.com',
+  root_url    => 'http://www.yourcompanydomain.com',
   port        => '80',
-  destination => '/opt/'
+  destination => '/opt'
 }
 ```
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,14 +24,11 @@ class rocketchat (
   $mongo_port     = $rocketchat::params::mongo_port,
   $mongo_replset  = $rocketchat::params::mongo_replset,
   $authsource     = $rocketchat::params::authsource,
-  $nodejs_deps    = $rocketchat::params::nodejs_deps,
   $manage_repos   = $rocketchat::params::manage_repos,
   $verbose        = $rocketchat::params::verbose,
 ) inherits rocketchat::params {
 
-  class { 'rocketchat::packages':
-    nodejs_deps => $nodejs_deps
-  }
+  class { 'rocketchat::packages': }
 
   if ($mongo_host == 'localhost') {
     class { 'rocketchat::database':

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -9,7 +9,7 @@ class rocketchat::install(
   $file_path = "${download_path}/rocket.tgz"
 
   $source = $package_source ? {
-    undef   => "https://rocket.chat/releases/${package_ensure}/download",
+    undef   => "https://download.rocket.chat/${package_ensure}",
     default => "${package_source}/rocket.chat-${package_ensure}.tgz",
   }
 

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -1,12 +1,10 @@
 # Packages that are neccesary for Rocket.Chat installation and configuration
-class rocketchat::packages(
-  $nodejs_deps
-) {
-
+class rocketchat::packages {
   class { 'nodejs':
-    version    => '4.x',
-    build_deps => $nodejs_deps,
-    before     => Exec['npm install']
+    repo_url_suffix           => '4.x',
+    nodejs_dev_package_ensure => 'present',
+    npm_package_ensure        => 'present',
+    before                    => Exec['npm install'],
   }
 
   package { 'curl':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,7 +10,6 @@ class rocketchat::params {
   $mongo_port     = 27017
   $mongo_replset  = undef
   $authsource     = undef
-  $nodejs_deps    = true
   $database_name  = 'rocket_chat'
   $root_url       = 'http://rocket.com'
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,16 +1,16 @@
 {
   "name": "rocketchat-rocketchat",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "Karol Kozakowski",
-  "summary": "Install and configures Rocket Chat Server",
+  "summary": "Installs and configures Rocket Chat Server",
   "license": "MIT",
-  "source": "github.com/rocketchat/puppet-rocketchat",
-  "project_page": "https://github.com/rocketchat/puppet-rocketchat",
-  "issues_url": "https://github.com/rocketchat/puppet-rocketchat/issues",
+  "source": "github.com/jkavan/puppet-rocketchat",
+  "project_page": "https://github.com/jkavan/puppet-rocketchat",
+  "issues_url": "https://github.com/jkavan/puppet-rocketchat/issues",
   "dependencies": [
       {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0",
        "name":"puppetlabs-mongodb","version_requirement":">= 0.17.0",
-       "name":"willdurand-nodejs","version_requirement":">= 2.0.0-alpha3",
+       "name":"puppet-nodejs","version_requirement":">= 4.0.1",
        "name":"maestrodev-wget","version_requirement":">=1.7.0",
        "name":"puppet-archive", "version_requirement":">=1.3.0"
       }

--- a/metadata.json
+++ b/metadata.json
@@ -4,9 +4,9 @@
   "author": "Karol Kozakowski",
   "summary": "Installs and configures Rocket Chat Server",
   "license": "MIT",
-  "source": "github.com/jkavan/puppet-rocketchat",
-  "project_page": "https://github.com/jkavan/puppet-rocketchat",
-  "issues_url": "https://github.com/jkavan/puppet-rocketchat/issues",
+  "source": "github.com/RocketChat/puppet-rocketchat",
+  "project_page": "https://github.com/RocketChat/puppet-rocketchat",
+  "issues_url": "https://github.com/RocketChat/puppet-rocketchat/issues",
   "dependencies": [
       {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0",
        "name":"puppetlabs-mongodb","version_requirement":">= 0.17.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -13,11 +13,6 @@ describe 'rocketchat' do
 
       context 'should contain classes with correct params' do
         it do
-          is_expected.to contain_class('rocketchat::packages').with(
-            'nodejs_deps' => true
-           )
-        end
-        it do
           is_expected.to contain_class('rocketchat::database').with(
             'port'         => '27017',
             'verbose'      => 'false',

--- a/spec/classes/packages_spec.rb
+++ b/spec/classes/packages_spec.rb
@@ -6,10 +6,6 @@ describe 'rocketchat::packages' do
       facts
     end
 
-    let(:params) do
-      { nodejs_deps: true }
-    end
-
     let(:pre_condition) {
       "class { 'rocketchat::install':
         download_path => '/tmp',

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -17,7 +17,7 @@ RSpec.configure do |c|
         target_module_path:  '/etc/puppetlabs/code/environments/production/modules')
       # Install dependencies
       on(host, puppet('module', 'install', 'puppetlabs-stdlib'))
-      on(host, puppet('module', 'install', '--version', "'>=2.0.0-alpha3'", 'willdurand-nodejs'))
+      on(host, puppet('module', 'install', '--version', "'>=4.0.1'", 'puppet-nodejs'))
       on(host, puppet('module', 'install', 'puppetlabs-apt'))
       on(host, puppet('module', 'install', 'puppetlabs-mongodb'))
       on(host, puppet('module', 'install', 'maestrodev-wget'))

--- a/templates/rocket.service.erb
+++ b/templates/rocket.service.erb
@@ -6,7 +6,7 @@ replstring = @mongo_replset.to_s != '' ? (authstring ? '&' : '?') + "replicaSet=
 Description=Rocket.Chat service
 
 [Service]
-ExecStart=/usr/local/bin/node <%= @destination %>/bundle/main.js
+ExecStart=/usr/bin/node <%= @destination %>/bundle/main.js
 Restart=always
 # Restart service after 10 seconds if node service crashes
 RestartSec=10


### PR DESCRIPTION
Since there's now an official module for the NodeJS, there's no need to use the one created by willdurand. Most people use the official one, so this should fix #12.

This PR also fixes issue #13 and contains a few other improvements.