### PR TITLE
metadata.json: fix dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,12 +8,11 @@
   "project_page": "https://github.com/rocketchat/puppet-rocketchat",
   "issues_url": "https://github.com/rocketchat/puppet-rocketchat/issues",
   "dependencies": [
-      {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0",
-       "name":"puppetlabs-mongodb","version_requirement":">= 0.17.0",
-       "name":"willdurand-nodejs","version_requirement":">= 2.0.0-alpha3",
-       "name":"maestrodev-wget","version_requirement":">=1.7.0",
-       "name":"puppet-archive", "version_requirement":">=1.3.0"
-      }
+      {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"},
+      {"name":"puppetlabs-mongodb","version_requirement":">= 0.17.0"},
+      {"name":"willdurand-nodejs","version_requirement":">= 2.0.0-alpha3"},
+      {"name":"maestrodev-wget","version_requirement":">=1.7.0"},
+      {"name":"puppet-archive", "version_requirement":">=1.3.0"}
   ],
     "operatingsystem_support": [
         {


### PR DESCRIPTION
All of them in one hash caused only the last keys to count, so librarian
pulled in puppet-archive, nothing else